### PR TITLE
fix: disallow losses on loss health check

### DIFF
--- a/scripts/SimulateHarvests.py
+++ b/scripts/SimulateHarvests.py
@@ -104,9 +104,7 @@ def main():
             and ppsPercentChange < 1
             and pricePerShareAfterTenHours >= 1 ** tokenDecimals
         )
-        profitAndLossOk = (gainDelta > 0 and lossDelta == 0) or (
-            lossDelta > 0 and gainDelta == 0
-        )
+        profitAndLossOk = gainDelta >= 0 and lossDelta == 0
         everythingOk = sharePriceOk and profitAndLossOk
 
         def boolDescription(bool):


### PR DESCRIPTION
Previous check didn't make sense to me since it permits losses and only returns false on 0 gain / 0 loss condition. But maybe I am missing the intent.